### PR TITLE
Fixed config key in set table

### DIFF
--- a/src/Models/MailManagerMail.php
+++ b/src/Models/MailManagerMail.php
@@ -58,7 +58,7 @@ class MailManagerMail extends Model
     {
         parent::__construct( $attributes );
 
-        $this->setTable( config('mail-manager.table_name') );
+        $this->setTable(config('mail_manager.table_name'));
     }
 
     /**


### PR DESCRIPTION
### Fixed config key in set table

Updates config key to same casing as elsewhere,  ex: `src/Migrations/2020_03_29_164100_create_mail_manager_mails_table.php:16`

When using a custom table name, the config was returning null and causing an sql error when it fell back to auto discovery of the table name.

`SQLSTATE[42S02]: Base table or view not found: 1146 Table 'testing.mail_manager_mails' doesn't exist (SQL: select * from mail_manager_mails where uuid = e3825a73-d174-40e3-b379-9ded1fd5e40c limit 1)`

